### PR TITLE
Fix API drift detection workflow does not submit issue on change

### DIFF
--- a/.github/workflows/api-drift-detection.yaml
+++ b/.github/workflows/api-drift-detection.yaml
@@ -51,10 +51,6 @@ jobs:
           npm run test:type
           echo 'done=true' >> "$GITHUB_OUTPUT"
 
-      - name: Propagate refresh errors
-        if: steps.refresh.outcome == 'failure' && steps.refresh.outputs.done != 'true'
-        run: exit 1
-
       # NOTE: If test have passed, API has not changed but there could be a file changes.
       #       However, the file changes can be ignored because it only consists of changes of changing values such as IDs, timestamps, etc.
       #       It's ideal to implement mitigation for file changes, but I have no idea how should I do it yet
@@ -93,3 +89,7 @@ jobs:
             --title "$TITLE" \
             --body-file "$body_file" \
             --label "$LABELS"
+
+      - name: Propagate refresh errors
+        if: steps.refresh.outcome == 'failure' && steps.refresh.outputs.done != 'true'
+        run: exit 1

--- a/.github/workflows/api-drift-detection.yaml
+++ b/.github/workflows/api-drift-detection.yaml
@@ -30,9 +30,6 @@ jobs:
           node-version-file: package.json
           cache: npm
 
-      - name: Update npm
-        run: npm install --global npm@latest
-
       - name: Install deps
         run: npm ci
 

--- a/.github/workflows/api-drift-detection.yaml
+++ b/.github/workflows/api-drift-detection.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Leave job summary for changes
         if: steps.refresh.outcome == 'failure' && steps.refresh.outputs.done == 'true'
         run: |
-          cat <<STEP_SUMMARY >> "$GITHUB_STEP_SUMMARY"
+          cat <<'STEP_SUMMARY' >> "$GITHUB_STEP_SUMMARY"
           ## Change Summary
 
           API test refresh failed with the following changes:


### PR DESCRIPTION
This PR fixes the remaining steps submitting an issue for API drift aren't executed because the error propagated too early.